### PR TITLE
Totara 29

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -529,6 +529,8 @@ function reengagement_scale_used($reengagementid, $scaleid) {
  * @return boolean True if the scale is used by any reengagement
  */
 function reengagement_scale_used_anywhere($scaleid) {
+    global $DB;
+
     if ($scaleid and $DB->record_exists('reengagement', array('grade' => -$scaleid))) {
         return true;
     } else {


### PR DESCRIPTION
This is just a potion of a fix, the column "grade" is not available on "reengagement" table. Either we have to add the column via "upgrade" script or just return false in "reengagement_scale_used_anywhere". Let me know what you think.