### PR TITLE
Allow reengagement periods to be smaller

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -813,7 +813,7 @@ function reengagement_get_readable_duration($duration, $periodstring = false) {
         } else if ($period == WEEKSECS) {
             $period = get_string('weeks', 'reengagement');
         } else
-            $period = get_string('weeks', 'reengagement');
+            $period = get_string('seconds', 'reengagement');
         }
     }
     return array($periodcount, $period); // Example 5, 60 is 5 minutes.

--- a/lib.php
+++ b/lib.php
@@ -785,34 +785,34 @@ function reengagement_supports($feature) {
 }
 
 /**
- * Process an arbitary number of seconds, and prepare to display it as X minutes, or Y hours or Z weeks.
+ * Process an arbitary number of seconds, and prepare to display it as 'W seconds', 'X minutes', or Y hours or Z weeks.
  *
  * @param int $duration FEATURE_xx constant for requested feature
  * @param boolean $periodstring - return period as string.
  * @return array
  */
 function reengagement_get_readable_duration($duration, $periodstring = false) {
-    if ($duration < 300) {
-        $period = 60;
-        $periodcount = 5;
-    } else {
-        $periods = array(604800, 86400, 3600, 60);
-        foreach ($periods as $period) {
-            if ((($duration % $period) == 0) || ($period == 60)) {
-                // Duration divides exactly into periods, or have reached the min. sensible period.
-                $periodcount = floor((int)$duration / (int)$period);
-                break;
-            }
+    $period = 1; // Default to dealing in seconds.
+    $periodcount = $duration; // Default to dealing in seconds.
+    $periods = array(WEEKSECS, DAYSECS, HOURSECS, MINSECS);
+    foreach ($periods as $period) {
+        if (($duration % $period) == 0) {
+            // Duration divides exactly into periods.
+            $periodcount = floor((int)$duration / (int)$period);
+            break;
         }
     }
     if ($periodstring) {
-        if ($period == 60) {
+        // Caller wants function to return in the format (30, 'minutes'), not (30, 60).
+        if ($period == MINSECS) {
             $period = get_string('minutes', 'reengagement');
-        } else if ($period == 3600) {
+        } else if ($period == HOURSECS) {
             $period = get_string('hours', 'reengagement');
-        } else if ($period == 86400) {
+        } else if ($period == DAYSECS) {
             $period = get_string('days', 'reengagement');
-        } else if ($period == 604800) {
+        } else if ($period == WEEKSECS) {
+            $period = get_string('weeks', 'reengagement');
+        } else
             $period = get_string('weeks', 'reengagement');
         }
     }

--- a/mod_form.php
+++ b/mod_form.php
@@ -293,8 +293,11 @@ class mod_reengagement_mod_form extends moodleform_mod {
                 if (isset($fromform->period) && isset($fromform->periodcount)) {
                     $fromform->duration = $fromform->period * $fromform->periodcount;
                 }
-                if (empty($fromform->duration) || $fromform->duration < 300) {
+                if (empty($fromform->duration)) {
                     $fromform->duration = 300;
+                }
+                if ($fromform->duration < 0)) {
+                    $fromform->duration = 0;
                 }
                 unset($fromform->period);
                 unset($fromform->periodcount);
@@ -303,8 +306,11 @@ class mod_reengagement_mod_form extends moodleform_mod {
             if (isset($fromform->emailperiod) && isset($fromform->emailperiodcount)) {
                 $fromform->emaildelay = $fromform->emailperiod * $fromform->emailperiodcount;
             }
-            if (empty($fromform->emaildelay) || $fromform->emaildelay < 300) {
+            if (empty($fromform->emaildelay)) {
                 $fromform->emaildelay = 300;
+            }
+            if ($fromform->emaildelay < 0) {
+                $fromform->emaildelay = 0;
             }
             unset($fromform->emailperiod);
             unset($fromform->emailperiodcount);
@@ -328,10 +334,11 @@ class mod_reengagement_mod_form extends moodleform_mod {
     public function add_completion_rules() {
         $mform =& $this->_form;
         $periods = array();
-        $periods[60] = get_string('minutes', 'reengagement');
-        $periods[3600] = get_string('hours', 'reengagement');
-        $periods[86400] = get_string('days', 'reengagement');
-        $periods[604800] = get_string('weeks', 'reengagement');
+        $periods[1] = get_string('seconds', 'reengagement');
+        $periods[MINSECS] = get_string('minutes', 'reengagement');
+        $periods[HOURSECS] = get_string('hours', 'reengagement');
+        $periods[DAYSECS] = get_string('days', 'reengagement');
+        $periods[WEEKSECS] = get_string('weeks', 'reengagement');
         $duration[] = &$mform->createElement('text', 'periodcount', '', array('class="periodcount"'));
         $mform->setType('periodcount', PARAM_INT);
         $duration[] = &$mform->createElement('select', 'period', '', $periods);
@@ -363,13 +370,13 @@ class mod_reengagement_mod_form extends moodleform_mod {
         if (!empty($data['emailperiod'])) {
             $duration = $data['emailperiod'] * $data['emailperiodcount'];
 
-            if ($duration < (60 * 60 * 24) && $data['remindercount'] > 2) {
+            if ($duration < (DAYSECS) && $data['remindercount'] > 2) {
                 // If less than 24hrs, make sure only 2 e-mails can be sent.
                 $errors['remindercount'] = get_string('frequencytoohigh', 'reengagement', 2);
-            } else if ($duration < (60 * 60 * 24 * 5) && $data['remindercount'] > 10) {
+            } else if ($duration < (5 * DAYSECS) && $data['remindercount'] > 10) {
                 // If less than 5 days, make sure only 10 e-mails can be sent.
                 $errors['remindercount'] = get_string('frequencytoohigh', 'reengagement', 10);
-            } else if ($duration < (60 * 60 * 24 * 15) && $data['remindercount'] > 26) {
+            } else if ($duration < (15 * DAYSECS) && $data['remindercount'] > 26) {
                 // If less than 15 days, make sure only 26 e-mails can be sent.
                 $errors['remindercount'] = get_string('frequencytoohigh', 'reengagement', 26);
             } else if ($data['remindercount'] > 40) {
@@ -378,7 +385,7 @@ class mod_reengagement_mod_form extends moodleform_mod {
             }
         }
 
-        if ($data['emailperiod'] == 60 && $data['emailperiodcount'] < 5) {
+        if ($data['emailperiod'] * $data['emailperiodcount'] < 300) {
             $errors['emaildelay'] = get_string('periodtoolow', 'reengagement');
         }
 


### PR DESCRIPTION
Note that this isn't tested.  It is mainly filed as a pull request to share progress, against the possibility I won't get back to it in a reasonable period, and someone else is willing to take up the reins.

Previously this mod ignored requests to set a reengagement to complete after 3 minutes (or smaller), and silently interpreted your request to be 300s (5 minutes).

This change should hopefully relax that.