### PR TITLE
Add seconds lang string

### DIFF
--- a/lang/en/reengagement.php
+++ b/lang/en/reengagement.php
@@ -121,6 +121,7 @@ $string['weeks'] = 'Weeks';
 $string['withselectedusers'] = 'With selected users...';
 $string['withselectedusers_help'] = '* Send message - For sending a message to one or more participants
 * Reset completion date by course access - For adjusting the reengagement completion date based on the first access to this course.';
+$string['seconds'] = 'Seconds';
 
 $string['privacy:metadata:reengagement'] = 'Reengagement ID';
 $string['privacy:metadata:userid'] = 'User id this record relates to';


### PR DESCRIPTION
https://github.com/catalyst/moodle-mod_reengagement/blob/master/mod_form.php#L337 wants a `seconds` lang string, but it doesn't exist