### PR TITLE
Fix 'Group: No group' filter in reengagement view

### DIFF
--- a/view.php
+++ b/view.php
@@ -208,7 +208,7 @@ if ($canedit) {
         }
     }
 
-    if ($groupid && ($course->groupmode != SEPARATEGROUPS || $canaccessallgroups)) {
+    if ($groupid && ($course->groupmode != SEPARATEGROUPS || $canaccessallgroups) && $groupid !== -1) {
         $grouprenderer = $PAGE->get_renderer('core_group');
         $groupdetailpage = new \core_group\output\group_details($groupid);
         echo $grouprenderer->group_details($groupdetailpage);


### PR DESCRIPTION
Tested on Moodle 3.9, made a test course, selected 'Group: No group' in the filter on the view page, given the error shown:
![Screenshot from 2020-07-03 13-56-25](https://user-images.githubusercontent.com/6424711/86423868-04d1dc00-bd35-11ea-8888-6cf2e070018b.png)

This pull request adds a check for the groupid of -1, it also appears to keep the filter of users in no groups working.