### PR TITLE
RE-73: Fix restrict access by groups not working

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -775,8 +775,15 @@ function reengagement_get_startusers($reengagement) {
     $modinfo = get_fast_modinfo($reengagement->courseid);
     $cm = $modinfo->get_cm($reengagement->cmid);
     $ainfomod = new \core_availability\info_module($cm);
+
+    // RE-73 - Filtering users by the availablilty settings.
+    $filteredusers = $ainfomod->filter_user_list($startusers);
+    $filtereduserids = array_map(function($obj){
+        return $obj->id;
+    }, $filteredusers);
+    // RE-73 - END.
+
     foreach ($startusers as $startcandidate) {
-        $information = '';
         if (empty($startcandidate->confirmed)) {
             // Exclude unconfirmed users. Typically this shouldn't happen, but if an unconfirmed user
             // has been enrolled to a course we shouldn't e-mail them about activities they can't access yet.
@@ -784,9 +791,12 @@ function reengagement_get_startusers($reengagement) {
             continue;
         }
         // Exclude users who can't see this activity.
-        if (!$ainfomod->is_available($information, false, $startcandidate->id, $modinfo)) {
+        // RE-73 - $info->is_available() does not seem to check groups. Changing this to use filtered users.
+        // Also removes the now unnecessary $information variable from above.
+        if (!in_array($startcandidate->id, $filtereduserids)) {
             unset($startusers[$startcandidate->id]);
         }
+        // RE-73 - END.
     }
 
     return $startusers;


### PR DESCRIPTION
The method used to check if a course module should be 'available'
to a user was not taking into account the possible restrict access
settings of specific user groups.

This has been changed to use the filter_user_list method which
should resolve that issue.