### PR TITLE
Fix participants table

### DIFF
--- a/classes/table/reengagement_participants.php
+++ b/classes/table/reengagement_participants.php
@@ -160,8 +160,8 @@ class reengagement_participants extends \table_sql implements dynamic_table {
         $bulkoperations = has_capability('moodle/course:bulkmessaging', $this->context);
         if ($bulkoperations) {
             $mastercheckbox = new \core\output\checkbox_toggleall('participants-table', true, [
-                'id' => 'select-all-participants',
-                'name' => 'select-all-participants',
+                'id' => 'select-all-reengagement-participants',
+                'name' => 'select-all-reengagement-participants',
                 'label' => get_string('selectall'),
                 'labelclasses' => 'sr-only',
                 'classes' => 'm-1',
@@ -236,7 +236,7 @@ class reengagement_participants extends \table_sql implements dynamic_table {
             $this->no_sorting('groups');
         }
 
-        $this->set_attribute('id', 'participants');
+        $this->set_attribute('id', "reengagement-index-participants-$this->cmid");
 
         $this->countries = get_string_manager()->get_list_of_countries(true);
         $this->extrafields = $extrafields;
@@ -301,7 +301,7 @@ class reengagement_participants extends \table_sql implements dynamic_table {
     public function col_roles($data) {
         global $OUTPUT;
 
-        $roles = isset($this->allroleassignments[$data->id]) ? $this->allroleassignments[$data->id] : [];
+        $roles = $this->allroleassignments[$data->id] ?? [];
         $editable = new \core_user\output\user_roles_editable($this->course,
             $this->context,
             $data,
@@ -504,11 +504,12 @@ class reengagement_participants extends \table_sql implements dynamic_table {
     public function set_filterset(filterset $filterset): void {
         global $DB;
         // Get the context.
-        $this->cmid = $filterset->get_filter('cmid')->current();
-        $this->courseid = $filterset->get_filter('courseid')->current();
-        $this->course = get_course($this->courseid);
+        $this->cmid = $filterset->get_filter('courseid')->current();
 
+        // Pretend the courseid is the cmid, as the core participants JS doesn't support additional filters.
         $cm = get_coursemodule_from_id('reengagement', $this->cmid, 0, false, MUST_EXIST);
+        $this->courseid = $cm->course;
+        $this->course = get_course($this->courseid);
         $this->reengagement = $DB->get_record('reengagement', array('id' => $cm->instance), '*', MUST_EXIST);
 
         $this->context = context_module::instance($this->cmid, MUST_EXIST);

--- a/classes/table/reengagement_participants_filterset.php
+++ b/classes/table/reengagement_participants_filterset.php
@@ -1,0 +1,53 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Contains the class used for the reengagement participants table filterset
+ *
+ * @package    mod_reengagement
+ * @copyright  2020 Catalyst IT
+ * @author     Alex Morris <alex.morris@catalyst.net.nz>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_reengagement\table;
+
+use core_table\local\filter\integer_filter;
+use core_user\table\participants_filterset;
+
+/**
+ * Reengagement table filterset, extends the core participants filterset to use its get_optional_filters function.
+ *
+ * @package    mod_reengagement
+ * @copyright  2020 Catalyst IT
+ * @author     Alex Morris <alex.morris@catalyst.net.nz>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class reengagement_participants_filterset extends participants_filterset {
+
+    /**
+     * Get the required filters.
+     *
+     * The required filters are the course module id and the course id.
+     *
+     * @return array.
+     */
+    public function get_required_filters(): array {
+        return [
+            'courseid' => integer_filter::class,
+        ];
+    }
+}


### PR DESCRIPTION
The replacement for the unified filter (the participants filterset)
does not support adding more than the courseid for a filter,
so I've had to pretend the cmid is the courseid to pass it back
to the reengagement table filterset when using the participants table.

Additionally I had to remove the participant filters allowing you to filter by
status etc at the top of the page. Again there isn't support for doing this
with anything but the course id.

For #94 #95 
