### PR TITLE
deprecated _get_completion_state() 

### DIFF
--- a/classes/completion/custom_completion.php
+++ b/classes/completion/custom_completion.php
@@ -1,0 +1,86 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Prints information about the reengagement to the user.
+ *
+ * @package    mod_reengagement
+ * @author     Sumaiya Javed <sumaiya.javed@catlayst.net.nz>
+ * @copyright  2016 Catalyst IT {@link http://www.catalyst.net.nz}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+
+namespace mod_reengagement\completion;
+
+use core_completion\activity_custom_completion;
+
+class custom_completion extends activity_custom_completion {
+
+    /**
+     * Fetches the completion state for a given completion rule.
+     *
+     * @param string $rule The completion rule.
+     * @return int The completion state.
+     */
+    public function get_state(string $rule): int {
+        global $DB;
+
+        $this->validate_rule($rule);
+
+        // Survey only supports duration as a custom rule.
+        $status = $DB->record_exists('course_modules_completion', ['coursemoduleid' => $this->cm->id, 'userid' => $this->userid]);
+        return $status ? COMPLETION_COMPLETE : COMPLETION_INCOMPLETE;      //  return $status ? COMPLETION_COMPLETE_PASS : COMPLETION_INCOMPLETE;
+    }
+
+    /**
+     * Fetch the list of custom completion rules that this module defines.
+     *
+     * @return array
+     */
+    public static function get_defined_custom_rules(): array {
+        return ['duration'];
+    }
+
+    /**
+    * Returns an associative array of the descriptions of custom completion rules.
+    *
+    * @return array
+    */
+   public function get_custom_rule_descriptions(): array {
+       return [
+           'duration' => get_string('duration', 'reengagement')
+       ];
+   }
+
+
+    /**
+     * Returns an array of all completion rules, in the order they should be displayed to users.
+     *
+     * @return array
+     */
+    public function get_sort_order(): array {
+        return [
+            'duration',
+        ];
+    }
+}
+
+
+
+
+
+

--- a/classes/table/reengagement_participants.php
+++ b/classes/table/reengagement_participants.php
@@ -174,9 +174,10 @@ class reengagement_participants extends \table_sql implements dynamic_table {
         $headers[] = get_string('fullname');
         $columns[] = 'fullname';
 
-        $extrafields = get_extra_user_fields($this->context);
+        $extrafields = \core_user\fields::for_identity($this->context)->get_required_fields();
+
         foreach ($extrafields as $field) {
-            $headers[] = get_user_field_name($field);
+            $headers[] = \core_user\fields::get_display_name($field); 
             $columns[] = $field;
         }
 

--- a/deprecatedlib.php
+++ b/deprecatedlib.php
@@ -1,0 +1,39 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * Obtains the automatic completion state for this survey based on the condition
+ * in feedback settings.
+ *
+ * @deprecated since Moodle 3.11
+ * @todo MDL-71196 Final deprecation in Moodle 4.3
+ * @see \mod_survey\completion\custom_completion
+ * @param stdClass $course Course
+ * @param cm_info|stdClass $cm Course-module
+ * @param int $userid User ID
+ * @param bool $type Type of comparison (or/and; can be used as return value if no conditions)
+ * @return bool True if completed, false if not, $type if conditions not set.
+ */
+
+function reengagement_get_completion_state($course, $cm, $userid, $type) {
+    global $DB;
+    if ($completion = $DB->get_record('course_modules_completion', array('coursemoduleid' => $cm->id, 'userid' => $userid))) {
+        return $completion->completionstate == COMPLETION_COMPLETE_PASS;
+    }
+    return false;
+}

--- a/lib.php
+++ b/lib.php
@@ -148,24 +148,6 @@ function reengagement_user_complete($course, $user, $mod, $reengagement) {
     return true;
 }
 
-/**
- * Obtains the automatic completion state for this forum based on any conditions
- * in forum settings.
- *
- * @param object $course Course
- * @param object $cm Course-module
- * @param int $userid User ID
- * @param bool $type Type of comparison (or/and; can be used as return value if no conditions)
- * @return bool True if completed, false if not. (If no conditions, then return
- *   value depends on comparison type)
- */
-function reengagement_get_completion_state($course, $cm, $userid, $type) {
-    global $DB;
-    if ($completion = $DB->get_record('course_modules_completion', array('coursemoduleid' => $cm->id, 'userid' => $userid))) {
-        return $completion->completionstate == COMPLETION_COMPLETE_PASS;
-    }
-    return false;
-}
 
 /**
  * Prints the recent activity.

--- a/view.php
+++ b/view.php
@@ -153,7 +153,9 @@ if ($canedit) {
     );
 
     echo $participanttablehtml;
-
+    $perpagevisible = '';
+    $perpagestring = '';
+    $perpagesize = '';
     $perpageurl = clone($baseurl);
     $perpageurl->remove_params('perpage');
     if ($perpage == SHOW_ALL_PAGE_SIZE && $participanttable->totalrows > DEFAULT_PAGE_SIZE) {


### PR DESCRIPTION
- Resolved deprecated _get_completion_state() callbacks 
- Resolved issues arising from missing variables declaration ; $perpagevisible, $perpagestring, $perpagesize

The precise errors that has been resolved are:

*_get_completion_state() callback functions such as reengagement_get_completion_state have been deprecated and should no longer be used. Please implement the custom completion class mod_reengagement\completion\custom_completion which extends \core_completion\activity_custom_completion.

    line 738 of /lib/completionlib.php: call to debugging()
    line 659 of /lib/completionlib.php: call to completion_info->internal_get_state()
    line 995 of /lib/completionlib.php: call to completion_info->update_state()
    line 661 of /course/modlib.php: call to completion_info->reset_all_state()
    line 166 of /course/modedit.php: call to update_moduleinfo()
    