### PR TITLE
Add remindercount to backup/restore

### DIFF
--- a/backup/moodle2/backup_reengagement_stepslib.php
+++ b/backup/moodle2/backup_reengagement_stepslib.php
@@ -49,7 +49,8 @@ class backup_reengagement_activity_structure_step extends backup_activity_struct
             'name', 'timecreated', 'timemodified',
             'emailuser', 'emailsubject', 'emailcontent', 'emailcontentformat',
             'duration', 'suppresstarget', 'emaildelay', 'emailrecipient',
-            'emailsubjectmanager', 'emailcontentmanager', 'emailcontentmanagerformat'));
+            'emailsubjectmanager', 'emailcontentmanager', 'emailcontentmanagerformat',
+            'remindercount'));
 
         $inprogresses = new backup_nested_element('inprogresses');
 


### PR DESCRIPTION
We heavily use moodles backup and restore functionality to duplicate a template course. Currently the reminder count has to be set manually again after each restore. 

This PR fixes this by adding the `remindercount` to the backup. 