### PR TITLE
Fix incorrect user being checked for access restrictions.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -788,11 +788,10 @@ function reengagement_get_startusers($reengagement) {
              AND u.id NOT IN ($alreadyripsql)";
 
     $startusers = $DB->get_records_sql($sql, $params);
-
-    $modinfo = get_fast_modinfo($reengagement->courseid);
-    $cm = $modinfo->get_cm($reengagement->cmid);
-    $ainfomod = new \core_availability\info_module($cm);
     foreach ($startusers as $startcandidate) {
+        $modinfo = get_fast_modinfo($reengagement->courseid, $startcandidate->id);
+        $cm = $modinfo->get_cm($reengagement->cmid);
+        $ainfomod = new \core_availability\info_module($cm);
         $information = '';
         if (empty($startcandidate->confirmed)) {
             // Exclude unconfirmed users. Typically this shouldn't happen, but if an unconfirmed user


### PR DESCRIPTION
By moving this code into the user loop and passing through the userid
it ensures the correct user is loaded into the modinfo object, which
is used in some access conditions for their checks (e.g. availability_group).

Fixes: #73