### PR TITLE
Correction completiontime and emailtime

### DIFF
--- a/classes/table/reengagement_participants.php
+++ b/classes/table/reengagement_participants.php
@@ -410,7 +410,7 @@ class reengagement_participants extends \table_sql implements dynamic_table {
      * @return string
      */
     public function col_emailtime($data) {
-        return userdate($data->emailtime, get_string('strftimedatetimeshort', 'langconfig'));
+        return $data->emailtime ? userdate($data->emailtime, get_string('strftimedatetimeshort', 'langconfig')) : '-';
     }
 
     /**
@@ -420,7 +420,7 @@ class reengagement_participants extends \table_sql implements dynamic_table {
      * @return string
      */
     public function col_completiontime($data) {
-        return userdate($data->completiontime, get_string('strftimedatetimeshort', 'langconfig'));
+        return $data->completiontime ? userdate($data->completiontime, get_string('strftimedatetimeshort', 'langconfig')) : '-';
     }
 
     /**


### PR DESCRIPTION
They were on 01/01/1970 when the field was empty. (see issue : https://github.com/catalyst/moodle-mod_reengagement/issues/124)