### PR TITLE
Debugging warning message in view page #133

### DIFF
--- a/view.php
+++ b/view.php
@@ -186,7 +186,6 @@ if ($canedit) {
     ), [], 'showall');
 
     $options = new stdClass();
-    $options->uniqueid = $participanttable->uniqueid;
     $options->courseid = $cm->id;
     $options->stateHelpIcon = $OUTPUT->help_icon('publishstate', 'notes');
 


### PR DESCRIPTION
report/participation/index.php actually is not using the uniqueid parameter. In this case, this is enough to avoid the debug message.