### PR TITLE
Fix #132: Decode links in 3 new text boxes after course task backup

### DIFF
--- a/backup/moodle2/restore_reengagement_activity_task.class.php
+++ b/backup/moodle2/restore_reengagement_activity_task.class.php
@@ -59,6 +59,10 @@ class restore_reengagement_activity_task extends restore_activity_task {
     public static function define_decode_contents() {
         $contents = array();
 
+        $contents[] = new restore_decode_content('reengagement', 'emailcontent');
+        $contents[] = new restore_decode_content('reengagement', 'emailcontentmanager');
+        $contents[] = new restore_decode_content('reengagement', 'emailcontentthirdparty');
+
         return $contents;
     }
 


### PR DESCRIPTION
Hello

I've submitted a fix for #132 issue.

**How to test**:
1. Edit a course, e.g., https://moodle-example-site.com/course/view.php?id=5
2. Add a new Reengagement activity, paste links to the course https://moodle-example-site.com/course/view.php?id=5 in content fields (text boxes)
* `Notification content (User)`
* `Notification content (Manager)`
* `Notification content (Third-party)
`
3. Save, then duplicate that activity
4. Links to the course in the new (duplicated) activity will be displayed as `$@COURSEVIEWBYID*5@$ 
`

Once the fix is applied links in content fields will be decoded properly and shown as `https://moodle-example-site.com/course/view.php?id=[course_id]`

**Reference**:
* Core: Encode content links in [backup/moodle2/backup_course_task.class.php](https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/backup/moodle2/backup_course_task.class.php#L153-L173)
* Core: Decode content in [backup/moodle2/restore_course_task.class.php](https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/backup/moodle2/restore_course_task.class.php#L140-L172)
* Reengagement plugin: Decode content in [backup/moodle2/restore_reengagement_activity_task.class.php](https://github.com/catalyst/moodle-mod_reengagement/blob/MOODLE_400_STABLE/backup/moodle2/restore_reengagement_activity_task.class.php#L55-L77)