### PR TITLE
Issue#145 Moodle 4.3 - Deprecated get_all_user_name_fields()

### DIFF
--- a/bulkchange.php
+++ b/bulkchange.php
@@ -94,7 +94,7 @@ if ($formaction == 'resetbyspecificdate') {
     exit;
 }
 
-$usernamefields = get_all_user_name_fields(true, 'u');
+$usernamefields = \core_user\fields::for_name()->get_sql($alias = 'u', false, '', '',  false)->selects;
 list($usql, $params) = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED, 'u');
 
 if ($formaction == 'resetbyfirstaccess') {

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022102900;   // The current module version.
-$plugin->requires  = 2021091700; // Requires 4.0.
+$plugin->version   = 2023100900;   // The current module version.
+$plugin->requires  = 2023100900; // Requires 4.3.
 $plugin->component = 'mod_reengagement';
-$plugin->release   = '4.2';
+$plugin->release   = '4.3';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->cron      = 0; // Now uses a scheduled task.
-$plugin->supported = [400, 400];
+$plugin->supported = [403, 403];


### PR DESCRIPTION
This checks if the new function is available and uses it, otherwise it will use the old one keeping it backwards compatible.