### PR TITLE
Fix JS error 4.4 - fixes #152

### DIFF
--- a/view.php
+++ b/view.php
@@ -187,6 +187,7 @@ if ($canedit) {
 
     $options = new stdClass();
     $options->courseid = $cm->id;
+    $options->uniqueid = $participanttable->uniqueid;
     $options->stateHelpIcon = $OUTPUT->help_icon('publishstate', 'notes');
 
     if ($bulkoperations) {


### PR DESCRIPTION
This fixes the JS error in #152 by adding the required `uniqueid` to `js_call_amd`
