### PR TITLE
Scheduled task related performance related improvement and minor changes

### DIFF
--- a/classes/table/reengagement_participants.php
+++ b/classes/table/reengagement_participants.php
@@ -451,7 +451,8 @@ class reengagement_participants extends \table_sql implements dynamic_table {
      */
     public function query_db($pagesize, $useinitialsbar = true) {
         list($twhere, $tparams) = $this->get_sql_where();
-        $psearch = new \mod_reengagement\table\reengagement_search($this->course, $this->context, $this->filterset);
+        $psearch = new \mod_reengagement\table\reengagement_search($this->course, $this->context, $this->filterset,
+            $this->reengagement->id);
 
         $total = $psearch->get_total_participants_count($twhere, $tparams);
 

--- a/classes/table/reengagement_search.php
+++ b/classes/table/reengagement_search.php
@@ -25,7 +25,10 @@
 
 namespace mod_reengagement\table;
 
+use context;
+use core_table\local\filter\filterset;
 use core_user\table\participants_search;
+use stdClass;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -40,6 +43,23 @@ require_once($CFG->dirroot . '/user/lib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class reengagement_search extends participants_search {
+    /**
+     * @var int $reengagementid The reengagement id
+     */
+    private $reengagementid;
+
+    /**
+     * Constructor
+     *
+     * @param stdClass $course The course object
+     * @param context $context The context
+     * @param filterset $filterset The filterset
+     * @param int $reengagementid The reengagement id
+     */
+    public function __construct(stdClass $course, context $context, filterset $filterset, int $reengagementid) {
+        parent::__construct($course, $context, $filterset);
+        $this->reengagementid = $reengagementid;
+    }
 
     /**
      * Generate the SQL used to fetch filtered data for the reengagement table.
@@ -50,7 +70,9 @@ class reengagement_search extends participants_search {
      */
     protected function get_participants_sql(string $additionalwhere, array $additionalparams): array {
         $sql = parent::get_participants_sql($additionalwhere, $additionalparams);
-        $sql['outerjoins'] .= 'LEFT JOIN {reengagement_inprogress} rip ON rip.userid = u.id';
+        $sql['params']['reengagementid'] = $this->reengagementid;
+        $sql['outerjoins'] .= 'LEFT JOIN {reengagement_inprogress} rip ON rip.userid = u.id ' .
+            'AND rip.reengagement = :reengagementid';
         $sql['outerselect'] .= ', rip.completiontime AS completiontime, rip.emailtime AS emailtime, '
             . 'rip.emailsent AS emailsent, rip.completed AS completed';
         return $sql;

--- a/classes/task/mark_complete.php
+++ b/classes/task/mark_complete.php
@@ -1,0 +1,161 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Ad-hoc task to process in progress reengagement completion.
+ *
+ * @package     mod_reengagement
+ * @copyright   (c) 2024, Enovation Solutions
+ * @author      Lai Wei <lai.wei@enovation.ie>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_reengagement\task;
+
+use cache;
+use context_module;
+use core\event\course_module_completion_updated;
+use core\task\adhoc_task;
+use stdClass;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/reengagement/lib.php');
+require_once($CFG->libdir . '/completionlib.php');
+require_once($CFG->libdir . '/enrollib.php');
+
+class mark_complete extends adhoc_task {
+
+    /**
+     * Get a descriptive name for this task (shown to admins).
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('adhoctaskmarkcompletetask', 'reengagement');
+    }
+
+    /**
+     * Do the job.
+     */
+    public function execute() {
+        global $DB;
+
+        $data = $this->get_custom_data();
+
+        $timenow = time();
+
+        $reengagementdata = $data->reengagement;
+        $cmid = $reengagementdata->cmid;
+        $inprogressdata = $data->inprogress;
+        $userid = $inprogressdata->userid;
+
+        // Check if user is still enrolled in the course.
+        $context = context_module::instance($cmid);
+        if (!is_enrolled($context, $userid, 'mod/reengagement:startreengagement', true)) {
+            mtrace("Reengagement: invalid inprogressid $inprogressdata->id. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogressdata->id]);
+
+            return;
+        }
+
+        // Ensure the in progress record still exists.
+        if (!$inprogress = $DB->get_record('reengagement_inprogress', ['id' => $inprogressdata->id])) {
+            mtrace("Reengagement: invalid inprogressid $inprogressdata->id. Delete the task.");
+
+            return;
+        }
+
+        // Ensure the reengagement activity is still exists.
+        if (!$reengagement = $DB->get_record('reengagement', ['id' => $reengagementdata->rid])) {
+            mtrace("Reengagement: invalid reengagementid $reengagementdata->rid. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+
+            return;
+        }
+
+        // Ensure the user still exists.
+        if (!$DB->record_exists('user', ['id' => $userid, 'deleted' => 0])) {
+            mtrace("Reengagement: invalid userid $userid. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+
+            return;
+        }
+
+        // Update completion record to indicate completion so the user can continue with any dependant activities.
+        $completionrecord = $DB->get_record('course_modules_completion', ['coursemoduleid' => $cmid, 'userid' => $userid]);
+        if (empty($completionrecord)) {
+            mtrace("Could not find completion record to update complete state, userid: $userid, cmid: $cmid - recreating record.");
+            // This might happen when reset_all_state has been triggered, deleting an "in-progress" record. so recreate it.
+            $completionrecord = new stdClass();
+            $completionrecord->coursemoduleid = $cmid;
+            $completionrecord->completionstate = COMPLETION_COMPLETE_PASS;
+            $completionrecord->viewed = COMPLETION_VIEWED;
+            $completionrecord->overrideby = null;
+            $completionrecord->timemodified = $timenow;
+            $completionrecord->userid = $userid;
+            $completionrecord->id = $DB->insert_record('course_modules_completion', $completionrecord);
+        } else {
+            mtrace("Updating activity complete state to completed, userid: $userid, cmid: $cmid.");
+            $updaterecord = new stdClass();
+            $updaterecord->id = $completionrecord->id;
+            $updaterecord->completionstate = COMPLETION_COMPLETE_PASS;
+            $updaterecord->timemodified = $timenow;
+            $DB->update_record('course_modules_completion', $updaterecord) . " \n";
+        }
+        $completioncache = cache::make('core', 'completion');
+        $completioncache->delete($userid . '_' . $reengagement->course);
+
+        // Trigger an event for course module completion changed.
+        $event = course_module_completion_updated::create([
+            'objectid' => $completionrecord->id,
+            'context' => $context,
+            'relateduserid' => $userid,
+            'other' => [
+                'relateduserid' => $userid,
+            ],
+        ]);
+        $event->add_record_snapshot('course_modules_completion', $completionrecord);
+        $event->trigger();
+
+        if (($reengagement->emailuser == REENGAGEMENT_EMAILUSER_COMPLETION) ||
+            ($reengagement->emailuser == REENGAGEMENT_EMAILUSER_NEVER) ||
+            ($reengagement->emailuser == REENGAGEMENT_EMAILUSER_TIME && !empty($inprogressdata->emailsent))) {
+            // No need to keep 'inprogress' record for later emailing.
+            // Delete inprogress record.
+            mtrace("mode $reengagement->emailuser reengagementid $reengagement->id. " .
+                "User marked complete, deleting inprogress record for user $userid");
+            $result = $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+        } else {
+            // Update inprogress record to indicate completion done.
+            mtrace("mode $reengagement->emailuser reengagementid $reengagement->id. " .
+                "Updating inprogress record for user $userid to indicate completion");
+            $updaterecord = new stdClass();
+            $updaterecord->id = $inprogress->id;
+            $updaterecord->completed = COMPLETION_COMPLETE;
+            $result = $DB->update_record('reengagement_inprogress', $updaterecord);
+        }
+        if (empty($result)) {
+            // Skip emailing. Go on to next completion record so we don't risk emailing users continuously each cron.
+            mtrace("Reengagement: not sending email to $userid regarding reengagementid $reengagement->id " .
+                "due to failure to update db.");
+        } else if ($reengagement->emailuser == REENGAGEMENT_EMAILUSER_COMPLETION) {
+            mtrace("Reengagement: sending email to $userid regarding reengagementid $reengagement->id due to completion.");
+            reengagement_email_user($reengagement, $inprogress);
+        }
+    }
+}
+

--- a/classes/task/mark_complete.php
+++ b/classes/task/mark_complete.php
@@ -37,6 +37,12 @@ require_once($CFG->dirroot . '/mod/reengagement/lib.php');
 require_once($CFG->libdir . '/completionlib.php');
 require_once($CFG->libdir . '/enrollib.php');
 
+/**
+ * Ad-hoc task to process in progress reengagement completion.
+ *
+ * @copyright  (c) 2024, Enovation Solutions
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class mark_complete extends adhoc_task {
 
     /**

--- a/classes/task/reengagement_adhoc_task.php
+++ b/classes/task/reengagement_adhoc_task.php
@@ -75,10 +75,18 @@ abstract class reengagement_adhoc_task extends adhoc_task {
             throw new moodle_exception('errorinvalidtask', 'mod_reengagement');
         }
 
-        // Check if the user is still enrolled in the course.
+        // Check if the course module is still valid.
         $context = context_module::instance($reengagementdata->cmid);
+        if (!$context) {
+            mtrace("Reengagement: invalid cmid $reengagementdata->cmid. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogressdata->id]);
+
+            throw new moodle_exception('errorinvalidtask', 'mod_reengagement');
+        }
+
+        // Check if the user is still enrolled in the course.
         if (!is_enrolled($context, $userid, 'mod/reengagement:startreengagement', true)) {
-            mtrace("Reengagement: user $userid is not enrolled in the course any more. " .
+            mtrace("Reengagement: user $userid is not enrolled in the course, or cannot start reengagement any more. " .
                 "Delete the in progress record and the task.");
             $DB->delete_records('reengagement_inprogress', ['id' => $inprogressdata->id]);
 

--- a/classes/task/reengagement_adhoc_task.php
+++ b/classes/task/reengagement_adhoc_task.php
@@ -1,0 +1,105 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Parent ad-hoc task class for reengagement that contains common methods.
+ *
+ * @package     mod_reengagement
+ * @copyright   (c) 2024, Enovation Solutions
+ * @author      Lai Wei <lai.wei@enovation.ie>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_reengagement\task;
+
+use context_module;
+use core\task\adhoc_task;
+use moodle_exception;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Parent ad-hoc task class for reengagement that contains common methods.
+ *
+ * @copyright  (c) 2024, Enovation Solutions
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+abstract class reengagement_adhoc_task extends adhoc_task {
+    /**
+     * Get a descriptive name for this task (shown to admins).
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('adhoctaskreengagementtask', 'reengagement');
+    }
+
+    /**
+     * Do the job - nothing to execute.
+     */
+    public function execute() {
+        // Nothing to execute.
+    }
+
+    /**
+     * Validate the task.
+     *
+     * @param object $reengagementdata The reengagement data
+     * @param object $inprogressdata The in progress data
+     * @return array
+     * @throws moodle_exception
+     */
+    protected function validate_task($reengagementdata, $inprogressdata) {
+        global $DB;
+
+        $userid = $inprogressdata->userid;
+
+        // Ensure the user still exists.
+        if (!$DB->record_exists('user', ['id' => $userid, 'deleted' => 0])) {
+            mtrace("Reengagement: invalid userid $userid. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogressdata->id]);
+
+            throw new moodle_exception('errorinvalidtask', 'mod_reengagement');
+        }
+
+        // Check if the user is still enrolled in the course.
+        $context = context_module::instance($reengagementdata->cmid);
+        if (!is_enrolled($context, $userid, 'mod/reengagement:startreengagement', true)) {
+            mtrace("Reengagement: user $userid is not enrolled in the course any more. " .
+                "Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogressdata->id]);
+
+            throw new moodle_exception('errorinvalidtask', 'mod_reengagement');
+        }
+
+        // Ensure the in progress record still exists.
+        if (!$inprogress = $DB->get_record('reengagement_inprogress', ['id' => $inprogressdata->id])) {
+            mtrace("Reengagement: invalid inprogressid $inprogressdata->id. Delete the task.");
+
+            throw new moodle_exception('errorinvalidtask', 'mod_reengagement');
+        }
+
+        // Ensure the reengagement activity is still exists.
+        if (!$reengagement = $DB->get_record('reengagement', ['id' => $reengagementdata->rid])) {
+            mtrace("Reengagement: invalid reengagementid $reengagementdata->rid. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+
+            throw new moodle_exception('errorinvalidtask', 'mod_reengagement');
+        }
+
+        return [$reengagement, $inprogress, $context];
+    }
+}

--- a/classes/task/reengagement_adhoc_task.php
+++ b/classes/task/reengagement_adhoc_task.php
@@ -29,8 +29,6 @@ use context_module;
 use core\task\adhoc_task;
 use moodle_exception;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Parent ad-hoc task class for reengagement that contains common methods.
  *

--- a/classes/task/send_email.php
+++ b/classes/task/send_email.php
@@ -35,6 +35,12 @@ require_once($CFG->dirroot . '/mod/reengagement/lib.php');
 require_once($CFG->libdir . '/completionlib.php');
 require_once($CFG->libdir . '/enrollib.php');
 
+/**
+ * Ad-hoc task to process email sending.
+ *
+ * @copyright  (c) 2024, Enovation Solutions
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class send_email extends adhoc_task {
 
     /**

--- a/classes/task/send_email.php
+++ b/classes/task/send_email.php
@@ -1,0 +1,124 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Ad-hoc task to process email sending.
+ *
+ * @package     mod_reengagement
+ * @copyright   (c) 2024, Enovation Solutions
+ * @author      Lai Wei <lai.wei@enovation.ie>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_reengagement\task;
+
+use context_module;
+use core\task\adhoc_task;
+use stdClass;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/mod/reengagement/lib.php');
+require_once($CFG->libdir . '/completionlib.php');
+require_once($CFG->libdir . '/enrollib.php');
+
+class send_email extends adhoc_task {
+
+    /**
+     * Get a descriptive name for this task (shown to admins).
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('adhoctasksendemailtask', 'reengagement');
+    }
+
+    /**
+     * Do the job.
+     */
+    public function execute() {
+        global $DB;
+
+        $data = $this->get_custom_data();
+
+        $timenow = time();
+
+        $reengagementdata = $data->reengagement;
+        $inprogressdata = $data->inprogress;
+        $userid = $inprogressdata->userid;
+
+        // Ensure the in progress record still exists.
+        if (!$inprogress = $DB->get_record('reengagement_inprogress', ['id' => $inprogressdata->id])) {
+            mtrace("Reengagement: invalid inprogressid $inprogressdata->id. Delete the task.");
+
+            return;
+        }
+
+        // Ensure the reengagement activity is still exists.
+        if (!$reengagement = $DB->get_record('reengagement', ['id' => $reengagementdata->rid])) {
+            mtrace("Reengagement: invalid reengagementid $reengagementdata->rid. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+
+            return;
+        }
+
+        // Ensure the user still exists.
+        if (!$DB->record_exists('user', ['id' => $userid, 'deleted' => 0])) {
+            mtrace("Reengagement: invalid userid $userid. Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+
+            return;
+        }
+
+        // Check if the user is still enrolled in the course.
+        $context = context_module::instance($reengagementdata->cmid);
+        if (!is_enrolled($context, $userid, 'mod/reengagement:startreengagement', true)) {
+            mtrace("Reengagement: user $userid is not enrolled in the course any more. " .
+                "Delete the in progress record and the task.");
+            $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+
+            return;
+        }
+
+        if ($inprogress->completed == COMPLETION_COMPLETE) {
+            mtrace("mode $reengagement->emailuser reengagementid $reengagement->id. " .
+                "User already marked complete. Deleting inprogress record for user $userid");
+            $result = $DB->delete_records('reengagement_inprogress', ['id' => $inprogress->id]);
+        } else {
+            mtrace("mode $reengagement->emailuser reengagementid $reengagement->id. " .
+                "Updating inprogress record to indicate email sent for user $userid");
+            $updaterecord = new stdClass();
+            $updaterecord->id = $inprogress->id;
+            if ($reengagement->remindercount > $inprogress->emailsent) {
+                $updaterecord->emailtime = $timenow + $reengagement->emaildelay;
+            }
+            $updaterecord->emailsent = $inprogress->emailsent + 1;
+            $result = $DB->update_record('reengagement_inprogress', $updaterecord);
+        }
+        if (!empty($result)) {
+            mtrace("Reengagement: sending email to $userid regarding reengagementid $reengagement->id due to emailduetime.");
+            $result = reengagement_email_user($reengagement, $inprogress);
+
+            // Queue next email if required.
+            if ($result && $inprogress->completed != COMPLETION_COMPLETE &&
+                $reengagement->remindercount > $inprogress->emailsent + 1) {
+                mtrace("Queueing next email for user $userid");
+                reengagement_queue_email_task($reengagementdata, $inprogressdata, $updaterecord->emailtime);
+                $DB->set_field('reengagement_inprogress', 'emailtime', $updaterecord->emailtime, ['id' => $inprogress->id]);
+            }
+        }
+    }
+}

--- a/lang/en/reengagement.php
+++ b/lang/en/reengagement.php
@@ -47,6 +47,7 @@ The Reengagement activity is very flexible, explore what you can do with it.
 // Alphabetized.
 $string['activitycompleted'] = 'This activity has been marked as complete';
 $string['adhoctaskmarkcompletetask'] = 'Mark reengagement complete';
+$string['adhoctaskreengagementtask'] = 'Parent reengagement task';
 $string['adhoctasksendemailtask'] = 'Send reengagement email';
 $string['afterdelay'] = 'After delay';
 $string['areyousure'] = 'Are you sure you want to make this change?';
@@ -96,6 +97,7 @@ $string['emailuser_help'] = 'When the activity should notify users: <ul>
 <li>On reengagement completion: Notify the user when the reengagement activity is completed.</li>
 <li>After Delay: Notify the user a set time after they have started the module.</li>
 </ul>';
+$string['errorinvalidtask'] = 'Invalid ad-hoc task';
 $string['errornoid'] = 'You must specify a course_module ID or an instance ID';
 $string['errorreengagementnotvalid'] = 'This reengagement module is not enabled for your account.
 Please contact your administrator if you feel this is in error';

--- a/lang/en/reengagement.php
+++ b/lang/en/reengagement.php
@@ -46,6 +46,8 @@ The Reengagement activity is very flexible, explore what you can do with it.
 
 // Alphabetized.
 $string['activitycompleted'] = 'This activity has been marked as complete';
+$string['adhoctaskmarkcompletetask'] = 'Mark reengagement complete';
+$string['adhoctasksendemailtask'] = 'Send reengagement email';
 $string['afterdelay'] = 'After delay';
 $string['areyousure'] = 'Are you sure you want to make this change?';
 $string['completion'] = 'Completion';
@@ -53,6 +55,10 @@ $string['completionwillturnon'] = 'Note that adding this activity to the course 
 $string['completeattimex'] = 'This activity will complete at {$a}';
 $string['completiontime'] = 'Completion time';
 $string['completiondatesupdated'] = 'Completion dates updated.';
+$string['configignorecategoryvisbility'] = 'Ignore category visibility';
+$string['configignorecategoryvisbilitydesc'] = 'If enabled, the scheduled task will ignore category and parent category visibility when checking course visibility. This requires the "Process visible courses only" setting to be enabled.';
+$string['configprocessvisiblecoursesonly'] = 'Process visible courses only';
+$string['configprocessvisiblecoursesonlydesc'] = 'If enabled, the scheduled task will only process courses that are visible to students, and skip hidden courses or courses in hidden categories.';
 $string['crontask'] = 'Reengagement cron task';
 $string['cronwarning'] = 'The Reengagment scheduled task has not been run in the past 8 hours - Cron must be configured to allow Reenagagements to function correctly.';
 $string['days'] = 'Days';
@@ -124,6 +130,8 @@ $string['remindercount_help'] = 'This is the number of times an e-mail is sent a
 <li>less than 5 days - limit of 10 reminders.</li>
 <li>less than 15 days - limit of 26 reminders.</li>
 <li>over 15 days - maximum limit of 40 reminders.</li></ul>';
+$string['removeinprogress'] = 'Remove in progress reengagements';
+$string['removeinprogressresults'] = 'Deleted in progress reengagements';
 $string['resetbyfirstaccess'] = 'By first course access and a duration of: {$a}';
 $string['resetbyenrolment'] = 'By enrolment creation date and a duration of: {$a}';
 $string['resetbyspecificdate'] = 'By specified date';

--- a/lib.php
+++ b/lib.php
@@ -288,8 +288,8 @@ function reengagement_check_course_visibility(int $courseid, bool $ignorecategor
 /**
  * Queue a task to mark a reengagement as complete.
  *
- * @param $reengagement
- * @param $inprogress
+ * @param object $reengagement
+ * @param object $inprogress
  * @return void
  */
 function reengagement_queue_mark_completion_task($reengagement, $inprogress) {
@@ -306,9 +306,9 @@ function reengagement_queue_mark_completion_task($reengagement, $inprogress) {
 /**
  * Queue an email sending task.
  *
- * @param $reengagement
- * @param $inprogress
- * @param $time
+ * @param object $reengagement
+ * @param object $inprogress
+ * @param int $time
  * @return void
  */
 function reengagement_queue_email_task($reengagement, $inprogress, $time) {

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin configurations for mod_reengagement.
+ *
+ * @package     mod_reengagement
+ * @copyright   (c) 2024, Enovation Solutions
+ * @author      Lai Wei <lai.wei@enovation.ie>
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+if ($ADMIN->fulltree) {
+    $settings->add(new admin_setting_configcheckbox('mod_reengagement/process_visible_courses_only',
+        get_string('configprocessvisiblecoursesonly', 'reengagement'),
+        get_string('configprocessvisiblecoursesonlydesc', 'reengagement'),
+        0));
+
+    $settings->add(new admin_setting_configcheckbox('mod_reengagement/ignore_category_visibility',
+        get_string('configignorecategoryvisbility', 'reengagement'),
+        get_string('configignorecategoryvisbilitydesc', 'reengagement'),
+        0));
+}

--- a/view.php
+++ b/view.php
@@ -187,7 +187,6 @@ if ($canedit) {
 
     $options = new stdClass();
     $options->courseid = $cm->id;
-    $options->uniqueid = $participanttable->uniqueid;
     $options->stateHelpIcon = $OUTPUT->help_icon('publishstate', 'notes');
 
     if ($bulkoperations) {

--- a/view.php
+++ b/view.php
@@ -187,6 +187,7 @@ if ($canedit) {
 
     $options = new stdClass();
     $options->courseid = $cm->id;
+    $options->uniqueid = $participanttable->uniqueid;
     $options->stateHelpIcon = $OUTPUT->help_icon('publishstate', 'notes');
 
     if ($bulkoperations) {


### PR DESCRIPTION
Hi Catalyst team,

We recent made some changes to the plugin with the main aim to improve the performance of the scheduled task.

**The performance issue**
The performance issue was raised from a Moodle site that we maintain, which have about 30 mod_reengagement activities in different courses, many of which are legacy courses that have been hidden, or moved to hidden course categories. Each run of the scheduled task now takes over 15 minutes to run, and the logic to mark completion and send emails are only reached after the logic to create in-progress records, at the end of the scheduled task. On some courses, mod_reengagement activities are used to allow users to access subsequent activities following a delay after another activity is completed, and the duration is set to be relatively short period, e.g. 30 minutes or 1 hour. Long scheduled task running time effectively adds a lot of extra time to the configured duration, resulting in confusion to users.

**The solution**
We have made two changes to improve this:

1. The current logic in the scheduled task to (1) mark completion and (2) send emails have been moved to two ad-hoc tasks. The ad-hoc tasks are created with `nextruntime` of the expected completion time / email time, so will be triggered by the Moodle cronjob separate from the scheduled task.
2. Two settings have been added to the plugin to allow site admins to control whether to process mod_reengagement activities in hidden courses, and whether (parent) category visibility needs to be considered. In our case, this alone hugely reduces the scheduled task running time.

**Bug fix in completion time / email time display**
This is related to issue #151. When a student access the plugin view.php page, the completion time / email time displayed is fetched by finding a random in progress record of the user, without limiting the in-progress record to the current mod_reengagement activity only. The pull request contains the fix to this issue.

**Other changes**
The PR also contains a small change to add an option to reset data belonging to the mod_reengagement plugin when the course is reset. I noticed that the reset function was actually implemented, but the option didn't exist, so the function would never be triggered.

Please review the changes, and let me know if you have any questions.

Regards,
Lai