### PR TITLE
Add user confirmation check in reengagement_get_startusers function sql

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -767,6 +767,7 @@ function reengagement_get_startusers($reengagement) {
               FROM {user} u
               JOIN ($esql) je ON je.id = u.id
              WHERE u.deleted = 0
+             AND u.confirmed = 1
              AND u.id NOT IN ($alreadycompletionsql)
              AND u.id NOT IN ($alreadyripsql)";
 
@@ -776,12 +777,6 @@ function reengagement_get_startusers($reengagement) {
         $cm = $modinfo->get_cm($reengagement->cmid);
         $ainfomod = new \core_availability\info_module($cm);
         $information = '';
-        if (empty($startcandidate->confirmed)) {
-            // Exclude unconfirmed users. Typically this shouldn't happen, but if an unconfirmed user
-            // has been enrolled to a course we shouldn't e-mail them about activities they can't access yet.
-            unset($startusers[$startcandidate->id]);
-            continue;
-        }
         // Exclude users who can't see this activity.
         if (!$ainfomod->is_available($information, false, $startcandidate->id, $modinfo)) {
             unset($startusers[$startcandidate->id]);


### PR DESCRIPTION
The updated code moves the confirmation check to the SQL query that retrieves the `startusers` list.