### PR TITLE
Fix/behat tests

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -316,7 +316,7 @@ class mod_reengagement_mod_form extends moodleform_mod {
             unset($fromform->emailperiodcount);
             // Some special handling for the wysiwyg editor field.
             $fromform->emailcontentformat = $fromform->emailcontent['format'];
-            $fromform->emailcontent = $fromform->emailcontent['text'];
+            $fromform->emailcontent = $fromform->emailcontent['text'] ?? '';
             if ($istotara) {
                 $fromform->emailcontentmanagerformat = $fromform->emailcontentmanager['format'];
                 $fromform->emailcontentmanager = $fromform->emailcontentmanager['text'];

--- a/tests/behat/reengagement.feature
+++ b/tests/behat/reengagement.feature
@@ -17,6 +17,6 @@ Feature: Teachers can create reengagment activity
       | C1     | teacher1 | editingteacher | ##yesterday## |
     And I log in as "teacher1"
     And I am on "Course 1" course homepage with editing mode on
-    And I add a "Reengagement" to section "1" and I fill the form with:
+    And I add a reengagement activity to course "Course 1" section "1" and I fill the form with:
       | Reengagement name        | Reengagement test       |
     Then I should see "Reengagement test"


### PR DESCRIPTION
Issue: 1
```
001 Scenario: Create Reengagment activity.                                # /home/runner/work/moodle-mod_reengagement/moodle-mod_reengagement/moodle/mod/reengagement/tests/behat/reengagement.feature:8
      And I add a "Reengagement" to section "1" and I fill the form with: # /home/runner/work/moodle-mod_reengagement/moodle-mod_reengagement/moodle/mod/reengagement/tests/behat/reengagement.feature:20
        Exception: Deprecated step, rather than using this step you can:
        - behat_course::i_add_to_course_section_and_i_fill_the_form_with
        - Set $CFG->behat_usedeprecated in config.php to allow the use of deprecated steps
                            if you don't have any other option in /home/runner/work/moodle-mod_reengagement/moodle-mod_reengagement/moodle/lib/behat/behat_deprecated_base.php:73
```

Issue 2: 
```
001 Scenario: Create Reengagment activity.                                # /home/runner/work/moodle-mod_reengagement/moodle-mod_reengagement/moodle/mod/reengagement/tests/behat/reengagement.feature:8
      And I add a "Reengagement" to section "1" and I fill the form with: # /home/runner/work/moodle-mod_reengagement/moodle-mod_reengagement/moodle/mod/reengagement/tests/behat/reengagement.feature:20
        Exception: Moodle exception: Exception - Warning: Undefined array key "text" in [dirroot]/mod/reengagement/mod_form.php on line 319 More information about this error
        
        Exception - Warning: Undefined array key "text" in [dirroot]/mod/reengagement/mod_form.php on line 319
```