### PR TITLE
Add possibility to not send emails for users that have emailstop=1

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -27,6 +27,7 @@
         <FIELD NAME="remindercount" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="how many times to send the email"/>
         <FIELD NAME="suppresstarget" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="ID of module that, if completed, should prevent an email being sent out."/>
         <FIELD NAME="emaildelay" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="604800" SEQUENCE="false" COMMENT="Time setting related to email"/>
+        <FIELD NAME="respectemailstop" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Should the email be suppressed for user that has emailstop preference set to true"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -176,5 +176,16 @@ function xmldb_reengagement_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2017102001, 'reengagement');
     }
 
+    if ($oldversion < 2024091800) {
+        //Define new field to suppress email for user that has emailstop preference set to true
+        $table = new xmldb_table('reengagement');
+        $field = new xmldb_field('respectemailstop', XMLDB_TYPE_INTEGER, '4', null, XMLDB_NOTNULL, null, '0');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_mod_savepoint(true, 2024091800, 'reengagement');
+    }
+
     return true;
 }

--- a/lang/en/reengagement.php
+++ b/lang/en/reengagement.php
@@ -141,6 +141,10 @@ $string['withselectedusers_help'] = '* Send message - For sending a message to o
 * Reset completion date by course access - For adjusting the reengagement completion date based on the first access to this course.';
 $string['seconds'] = 'Seconds';
 
+$string['respectemailstop'] = "Suppress notification for those users that have 'emailstop' set to true";
+$string['respectemailstop_help'] = "This option instructs the activity to suppress notifications for those users that have 'emailstop' preference set to true";
+
+
 $string['privacy:metadata:reengagement'] = 'Reengagement ID';
 $string['privacy:metadata:userid'] = 'User id this record relates to';
 $string['privacy:metadata:completiontime'] = 'When this module will be complete';

--- a/lib.php
+++ b/lib.php
@@ -414,6 +414,13 @@ function reengagement_email_user($reengagement, $inprogress) {
         // User has been deleted - don't send an e-mail.
         return true;
     }
+    if (!empty($reengagement->respectemailstop) && !empty($user->emailstop)) {
+        //User has "emailstop" preference set to true
+        //Don't send
+        debugging('', DEBUG_DEVELOPER) && mtrace('Reengagement modules: User:'.$user->id.
+            ' has emailstop preference set to true, Email not sent');
+        return true;
+    }
     if (!empty($reengagement->suppresstarget)) {
         $targetcomplete = reengagement_check_target_completion($user->id, $reengagement->suppresstarget);
         if ($targetcomplete) {

--- a/mod_form.php
+++ b/mod_form.php
@@ -179,6 +179,10 @@ class mod_reengagement_mod_form extends moodleform_mod {
         $mform->hideif('suppresstarget', 'suppressemail', 'notchecked');
         $mform->addHelpbutton('suppresstarget', 'suppresstarget', 'reengagement');
 
+        $mform->addElement('advcheckbox', 'respectemailstop', get_string('respectemailstop', 'reengagement'));
+        $mform->addHelpbutton('respectemailstop', 'respectemailstop', 'reengagement');
+
+
         // Add standard elements, common to all modules.
         $this->standard_coursemodule_elements();
         if ($mform->elementExists('completion')) {

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024081300;   // The current module version.
-$plugin->release   = 2023020804;
+$plugin->version   = 2024091800;   // The current module version.
+$plugin->release   = 2024091800;
 $plugin->requires  = 2024081000; // Requires 4.5.
 $plugin->component = 'mod_reengagement';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This update introduces a new feature to the mod_reengagement plugin, allowing the exclusion of users who have the "emailstop" preference set to true from receiving emails.

- The functionality is controlled by a flag at the activity level.
- By default, the flag is set to false to preserve the existing behaviour, ensuring emails are sent to all users as before.