### PR TITLE
Add check for pending adhoc tasks before executing new Scheduled task

### DIFF
--- a/classes/task/cron_task.php
+++ b/classes/task/cron_task.php
@@ -49,7 +49,32 @@ class cron_task extends \core\task\scheduled_task {
     public function execute() {
         global $CFG;
         require_once($CFG->dirroot . '/mod/reengagement/lib.php');
+
+        if ($this->has_pending_adhoc_tasks()) {
+            mtrace('Pending reengagement adhoc task already exists, skipping execution.');
+            return;
+        }
+
         reengagement_crontask();
     }
 
+    /**
+     * Check if pending adhoc tasks created by this task already exist.
+     *
+     * @return bool
+     */
+    protected function has_pending_adhoc_tasks() {
+        global $DB;
+        $pendingtasks = $DB->get_records_sql(
+            "SELECT * FROM {task_adhoc}
+             WHERE classname = :classname
+             AND faildelay = 0
+             AND nextruntime <= :time",
+            [
+                'classname' => '\\mod_reengagement\\task\\reengagement_adhoc_task',
+                'time' => time()
+            ]
+        );
+        return !empty($pendingtasks);
+    }
 }


### PR DESCRIPTION
This PR introduces a check for pending adhoc tasks before executing a new scheduled task in the `cron_task` class. By doing so, it ensures that redundant executions of the reengagement cron task are avoided when there are already pending tasks. This is particularly important as Moodle does not create redundant adhoc tasks by itself, but scheduled tasks might generate a large number of adhoc tasks when there are many course modules. Without completing the previous iteration of adhoc tasks, creating new ones would just add to the queue, potentially creating a massive queue and possible bottleneck.

**Changes**

- Modified `classes/task/cron_task.php`
         -     Added a method `has_pending_adhoc_tasks` to check for existing pending adhoc tasks.
         -      Updated the `execute` method to skip execution if there are pending adhoc tasks.