### PR TITLE
Fix #181: Queue adhoc tasks by duration

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -190,7 +190,7 @@ function reengagement_crontask() {
                     INNER JOIN {course_modules} cm on cm.instance = r.id
                           JOIN {modules} m on m.id = cm.module
                          WHERE m.name = 'reengagement' AND cm.deletioninprogress = 0
-                      ORDER BY r.id ASC";
+                      ORDER BY r.duration ASC";
 
     $reengagements = $DB->get_recordset_sql($reengagementssql);
     if (!$reengagements->valid()) {


### PR DESCRIPTION
**Description:** This resolves issue #181 by changing the SQL used to retrieve the re-engagement modules. No functional changes.

**Testing instructions:**

0. Cherry pick the changes in https://github.com/catalyst/moodle-mod_reengagement/pull/186 (both can be tested at the same time)
1. Create new test course
2. Enable activity completion
3. Add re-engagement module
4. Under 'Completion conditions', select a reengagement duration of 1 week
5. Add another re-engagement module and select a duration of 1 hour
6. Execute the cron task with `php admin/cli/scheduled_task.php --execute=mod_reengagement\\task\\cron_task`
7. Confirm that the output message looks like this, where the first module queued should have a higher ID:
```
Execute scheduled task: Reengagement cron task (mod_reengagement\task\cron_task)
... started 00:18:38. Current memory use 18.1 MB.
Queued re-engagement module: (rid: 2, cmid: 66)
Queued re-engagement module: (rid: 1, cmid: 65)
```
8. Run the task again and confirm that the tasks were not added to the queue (skipped)
```
Execute scheduled task: Reengagement cron task (mod_reengagement\task\cron_task)
... started 00:43:37. Current memory use 18.1 MB.
Skipped queueing re-engagement module: (rid: 2, cmid: 66)
Skipped queueing re-engagement module: (rid: 1, cmid: 65)
```
