### PR TITLE
Fix #181: Queue adhoc tasks by duration

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -190,7 +190,7 @@ function reengagement_crontask() {
                     INNER JOIN {course_modules} cm on cm.instance = r.id
                           JOIN {modules} m on m.id = cm.module
                          WHERE m.name = 'reengagement' AND cm.deletioninprogress = 0
-                      ORDER BY r.id ASC";
+                      ORDER BY r.duration ASC";
 
     $reengagements = $DB->get_recordset_sql($reengagementssql);
     if (!$reengagements->valid()) {


### PR DESCRIPTION
**Description:** See https://github.com/catalyst/moodle-mod_reengagement/pull/183 for more details. This applies that change to the MOODLE_400_STABLE branch.