### PR TITLE
195 fix task 400

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ jobs:
     # Required if you plan to publish (uncomment the below)
     secrets:
       moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}
-    with:
-      disable_phpunit: true

--- a/classes/task/reengagement_adhoc_task.php
+++ b/classes/task/reengagement_adhoc_task.php
@@ -50,6 +50,11 @@ class reengagement_adhoc_task extends adhoc_task {
             return;
         }
 
+        // Ensure the coursemodule still exists, otherwise exit early.
+        if (empty($data->cmid) || !$DB->record_exists('course_modules', ['id' => $data->cmid])) {
+            return;
+        }
+
         // Get a list of users who are eligible to start this module.
         $startusers = reengagement_get_startusers($data);
 

--- a/tests/reengagement_adhoc_task_test.php
+++ b/tests/reengagement_adhoc_task_test.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace mod_reengagement;
+
+use advanced_testcase;
+use mod_reengagement\task\reengagement_adhoc_task;
+
+/**
+ * Reengagement adhoc task tests
+ *
+ * @package    mod_reengagement
+ * @author     Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright  2025 Catalyst IT {@link http://www.catalyst-au.net}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \mod_reengagement\task\reengagement_adhoc_task
+ */
+class reengagement_adhoc_task_test extends advanced_testcase {
+    /**
+     * Tests adhoc task exits gracefully without any customdata.
+     */
+    public function test_adhoc_task_no_customdata() {
+        $task = new reengagement_adhoc_task();
+        $task->execute();
+    }
+
+    /**
+     * Tests adhoc task exits gracefully with a missing cmid in customdata.
+     */
+    public function test_adhoc_task_missing_cmid_customdata() {
+        // No cmid is customdata, should exit early and not throw exception.
+        $task = new reengagement_adhoc_task();
+        $task->set_custom_data(['cmid' => null]);
+        $task->execute();
+    }
+
+    /**
+     * Tests adhoc task exits gracefully with an invalid cmid in customdata.
+     */
+    public function test_adhoc_task_coursemodule_does_not_exist() {
+        // This coursemodule does not exist, it should gracefully exit.
+        $task = new reengagement_adhoc_task();
+        $task->set_custom_data(['cmid' => 12345]);
+        $task->execute();
+    }
+}


### PR DESCRIPTION
Closes #195 

**Changes**
- Exits task early if cmid is missing, or course module does not exist.
- Enable phpunit in ci, to run test for above scenario

**Testing**
- Covered by unit tests

**To Do**
- [x] Cherry pick to 404 branch https://github.com/catalyst/moodle-mod_reengagement/pull/197
- [x] Cherry pick to 405 branch https://github.com/catalyst/moodle-mod_reengagement/pull/198