### PR TITLE
Fix deprecated form-inline usage by replacing it with Bootstrap flex utilities for Moodle 5.1 compatibility

### DIFF
--- a/view.php
+++ b/view.php
@@ -186,7 +186,7 @@ if ($canedit) {
     ), [], 'showall');
 
     if ($bulkoperations) {
-        echo '<br /><div class="buttons"><div class="form-inline">';
+        echo '<br /><div class="buttons"><div class="d-flex flex-wrap gap-2 align-items-center">';
 
         if ($participanttable->get_page_size() < $participanttable->totalrows) {
             // Select all users, refresh table showing all users and mark them all selected.


### PR DESCRIPTION
Fixes 
- https://github.com/catalyst/moodle-mod_reengagement/issues/213

## Description
- Fix deprecated form-inline usage by replacing it with Bootstrap flex utilities for Moodle 5.1 compatibility described on issue 213